### PR TITLE
Add the ability to use CAF with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
 	"name": "caf",
-	"version": "8.0.0",
+	"version": "8.0.1",
 	"description": "Cancelable Async Flows: a wrapper to treat generators as cancelable async functions",
 	"main": "./index.js",
+	"browser": "./src/caf.js",
 	"scripts": {
 		"test": "node scripts/node-tests.js",
 		"test:dist": "TEST_DIST=true npm test",


### PR DESCRIPTION
The latest version of CAF doesn't work with webpack:
```
WARNING in ./node_modules/caf/index.js 5:0-71
Critical dependency: the request of a dependency is an expression
 @ ./src/index.js

WARNING in ./node_modules/caf/index.js 6:17-65
Critical dependency: the request of a dependency is an expression
 @ ./src/index.js
```
because it can't parse the dynamic expression in the `index.js`.
I think that we need to use the `browser` package.json field for bundlers.