### PR TITLE
Fix the browser path in package.json for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "caf",
-	"version": "8.0.1",
+	"version": "8.0.2",
 	"description": "Cancelable Async Flows: a wrapper to treat generators as cancelable async functions",
 	"main": "./index.js",
-	"browser": "./src/caf.js",
+	"browser": "./dist/caf.js",
 	"scripts": {
 		"test": "node scripts/node-tests.js",
 		"test:dist": "TEST_DIST=true npm test",


### PR DESCRIPTION
This is a fix for a seemingly wrong path that was added to the package.json with the most recent pull request (8.0.1) https://github.com/getify/CAF/pull/10 

I've also included the version number upgrade (8.0.2)