### PR TITLE
Adds the abort reason to signal.reason on cancel

### DIFF
--- a/src/caf.src.js
+++ b/src/caf.src.js
@@ -19,7 +19,9 @@
 			this.signal.pr.catch(v=>v);
 		}
 		abort(reason) {
-			this.signal.reason = reason;
+			if (!("reason" in this.signal)) {
+				this.signal.reason = reason;
+			}
 			this.rej(reason);
 			this.controller.abort();
 		}

--- a/src/caf.src.js
+++ b/src/caf.src.js
@@ -19,6 +19,7 @@
 			this.signal.pr.catch(v=>v);
 		}
 		abort(reason) {
+			this.signal.reason = reason;
 			this.rej(reason);
 			this.controller.abort();
 		}

--- a/src/caf.src.js
+++ b/src/caf.src.js
@@ -11,7 +11,12 @@
 			this.signal = controller.signal;
 			// note: => arrow function used here for lexical this
 			var handleReject = (res,rej) => {
-				once(this.signal,"abort",rej);
+				once(this.signal, "abort", r => {
+					if (!("reason" in this.signal)) {
+						this.signal.reason = r;
+					}
+					rej(r);
+				});
 				this.rej = rej;
 			};
 			this.signal.pr = new Promise(handleReject);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -627,6 +627,54 @@ QUnit.test( "signalAll()", async function test(assert){
 	assert.deepEqual( pActual, pExpected, "main: result" );
 } );
 
+QUnit.test( "checking aborted reason", async function test(assert){
+	var cancelReason = 'testing cancel req';
+	function *main(signal, ms) {
+		try {
+			for (let i = 0; i < 5; i++) {
+				assert.step(`step: ${i}`);
+				yield CAF.delay(ms,signal);
+			}
+		}
+		finally {
+			if (signal.aborted) {
+				assert.step("step: in canceled finally");
+				assert.strictEqual(signal.reason, cancelReason, 'unexpected cancel reason');
+			}
+			else {
+				assert.step("step: uhoh signal should be aborted");
+			}
+		}
+	}
+
+	var token = new CAF.cancelToken();
+	main = CAF(main);
+
+	var rExpected = [
+		"step: 0",
+		"step: 1",
+		"step: 2",
+		"step: in canceled finally"
+	];
+	var pExpected = cancelReason;
+
+	setTimeout(function t(){
+		token.abort(cancelReason);
+	},50);
+
+	// rActual;
+	try {
+		await main(token.signal,20);
+	}
+	catch (err) {
+		var pActual = err;
+	}
+
+	assert.expect( 7 ); // note: 3 assertions + 4 `step(..)` calls
+	assert.verifySteps( rExpected, "ignore canceled after 3 iterations" );
+	assert.strictEqual( pActual, pExpected, "unexpected final result" );
+} );
+
 
 
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -677,8 +677,48 @@ QUnit.test( "checking aborted reason", async function test(assert){
 	assert.strictEqual( pActual, pExpected, "unexpected final result" );
 } );
 
+QUnit.test( "checking aborted reason exists + raw AbortController", async function test(assert){
+	function *main(signal, ms) {
+		try {
+			for (let i = 0; i < 5; i++) {
+				assert.step(`step: ${i}`);
+				yield CAF.delay(ms,signal);
+			}
+		}
+		finally {
+			if (signal.aborted) {
+				assert.step("step: in canceled finally");
+				assert.ok('reason' in signal, 'signal reason missing');
+			}
+		}
+	}
 
+	var ac = new AbortController();
+	main = CAF(main);
 
+	var rExpected = [
+		"step: 0",
+		"step: 1",
+		"step: 2",
+		"step: in canceled finally"
+	];
+
+	setTimeout(function t(){
+		ac.abort();
+	},50);
+
+	// rActual;
+	try {
+		await main(ac,20);
+	}
+	catch (err) {
+		var pActual = err;
+	}
+
+	assert.expect( 7 ); // note: 3 assertions + 4 `step(..)` calls
+	assert.verifySteps( rExpected, "ignore canceled after 3 iterations" );
+	assert.ok( pActual && pActual.type === 'abort', "expected final abort event to be thrown" );
+} );
 
 function _hasProp(obj,prop) {
 	return Object.hasOwnProperty.call( obj, prop );

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -660,6 +660,8 @@ QUnit.test( "checking aborted reason", async function test(assert){
 
 	setTimeout(function t(){
 		token.abort(cancelReason);
+		// call abort a second time right away to make sure it doesn't change things
+		token.abort("uhoh reason");
 	},50);
 
 	// rActual;


### PR DESCRIPTION
Related to https://github.com/getify/CAF/issues/18
Sweet! This worked out quite well. Good idea, and thanks to your friend as well.

I've added the reason onto the signal in the most basic way here, so let me know if you'd like it done differently. 
I can think of one potential error if you call abort twice with different reasons, the 1st reason will be overwritten and it will be wrong in the finally block.
```
cancelToken.abort('reason1');
cancelToken.abort('reason2');
```
I don't see any other tests for bad usage of the library though, so let me know if you want me to protect against this or not.