### PR TITLE
load polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,4 @@
 
 var path = require("path");
 
-require(path.join(__dirname,"dist","abortcontroller-polyfill-only.js"));
 module.exports = require(path.join(__dirname,"src","caf.js"));

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,5 +1,9 @@
 "use strict";
 
+const path = require('path');
+
+require(path.resolve(__dirname,'../dist/abortcontroller-polyfill-only.js'));
+
 const CLEANUP_FN = Symbol("Cleanup Function");
 const TIMEOUT_TOKEN = Symbol("Timeout Token");
 


### PR DESCRIPTION
now polyfill loads automatically for all the versions of Node.
no need to install an external package of abortcontroller-controller for Node 14.x or below
it resolves issue #23.